### PR TITLE
Fix: respect all fields in WithPoolConfig

### DIFF
--- a/connection_provider.go
+++ b/connection_provider.go
@@ -63,15 +63,7 @@ func (p *ConnectionProvider) Connect(ctx context.Context, databaseName string) (
 		return nil, fmt.Errorf("failed to parse connection string: %w", err)
 	}
 
-	// Apply pool configuration settings if provided.
-	// MaxConns must be checked (pgx validates >= 1).
-	if p.poolConfig.MaxConns != 0 {
-		config.MaxConns = p.poolConfig.MaxConns
-	}
-	// These could be set directly (0 is safe).
-	config.MinConns = p.poolConfig.MinConns
-	config.MaxConnLifetime = p.poolConfig.MaxConnLifetime
-	config.MaxConnIdleTime = p.poolConfig.MaxConnIdleTime
+	p.applyPoolConfig(config)
 
 	pool, err := pgxpool.NewWithConfig(ctx, config)
 	if err != nil {
@@ -90,6 +82,50 @@ func (p *ConnectionProvider) Connect(ctx context.Context, databaseName string) (
 		provider: p,
 		dbName:   databaseName,
 	}, nil
+}
+
+// applyPoolConfig merges user-provided pool options into a parsed config,
+// preserving pgx defaults for fields where zero has special meaning.
+//
+// ConnConfig is intentionally not copied from p.poolConfig to preserve
+// Connect(databaseName) behavior that derives the target database from the
+// parsed connection string for each call.
+func (p *ConnectionProvider) applyPoolConfig(config *pgxpool.Config) {
+	// HealthCheckPeriod must be checked (pgx validates > 0).
+	if p.poolConfig.HealthCheckPeriod != 0 {
+		config.HealthCheckPeriod = p.poolConfig.HealthCheckPeriod
+	}
+	// MaxConns must be checked (pgx validates >= 1).
+	if p.poolConfig.MaxConns != 0 {
+		config.MaxConns = p.poolConfig.MaxConns
+	}
+
+	// MinConns: 0 is a valid value (no minimum), assign unconditionally.
+	config.MinConns = p.poolConfig.MinConns
+	if p.poolConfig.MaxConnLifetime != 0 {
+		config.MaxConnLifetime = p.poolConfig.MaxConnLifetime
+	}
+	if p.poolConfig.MaxConnIdleTime != 0 {
+		config.MaxConnIdleTime = p.poolConfig.MaxConnIdleTime
+	}
+	if p.poolConfig.MaxConnLifetimeJitter != 0 {
+		config.MaxConnLifetimeJitter = p.poolConfig.MaxConnLifetimeJitter
+	}
+	if p.poolConfig.BeforeConnect != nil {
+		config.BeforeConnect = p.poolConfig.BeforeConnect
+	}
+	if p.poolConfig.AfterConnect != nil {
+		config.AfterConnect = p.poolConfig.AfterConnect
+	}
+	if p.poolConfig.BeforeAcquire != nil {
+		config.BeforeAcquire = p.poolConfig.BeforeAcquire
+	}
+	if p.poolConfig.AfterRelease != nil {
+		config.AfterRelease = p.poolConfig.AfterRelease
+	}
+	if p.poolConfig.BeforeClose != nil {
+		config.BeforeClose = p.poolConfig.BeforeClose
+	}
 }
 
 // GetNoRowsSentinel implements pgdbtemplate.ConnectionProvider.GetNoRowsSentinel.

--- a/connection_provider_test.go
+++ b/connection_provider_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/andrei-polukhin/pgdbtemplate"
@@ -89,6 +91,13 @@ func TestPgxConnectionProvider(t *testing.T) {
 		baseConnString := testConnectionStringFuncPgx("postgres")
 		poolConfig, err := pgxpool.ParseConfig(baseConnString)
 		c.Assert(err, qt.IsNil)
+		var afterConnectCalls atomic.Int32
+		poolConfig.AfterConnect = func(context.Context, *pgx.Conn) error {
+			afterConnectCalls.Add(1)
+			return nil
+		}
+		poolConfig.HealthCheckPeriod = 2 * time.Second
+		poolConfig.MaxConnLifetimeJitter = 5 * time.Second
 		poolConfig.MaxConns = 3
 		poolConfig.MinConns = 1
 
@@ -101,6 +110,10 @@ func TestPgxConnectionProvider(t *testing.T) {
 		conn, err := provider.Connect(ctx, "postgres")
 		c.Assert(err, qt.IsNil)
 		defer func() { c.Assert(conn.Close(), qt.IsNil) }()
+		pgxConn, ok := conn.(*pgdbtemplatepgx.DatabaseConnection)
+		c.Assert(ok, qt.IsTrue)
+		c.Assert(pgxConn.Pool.Config().HealthCheckPeriod, qt.Equals, 2*time.Second)
+		c.Assert(pgxConn.Pool.Config().MaxConnLifetimeJitter, qt.Equals, 5*time.Second)
 
 		// Verify the connection works.
 		var value int
@@ -108,6 +121,65 @@ func TestPgxConnectionProvider(t *testing.T) {
 		err = row.Scan(&value)
 		c.Assert(err, qt.IsNil)
 		c.Assert(value, qt.Equals, 1)
+		c.Assert(afterConnectCalls.Load() >= int32(1), qt.IsTrue)
+	})
+
+	c.Run("Pool hooks are invoked", func(c *qt.C) {
+		c.Parallel()
+		baseConnString := testConnectionStringFuncPgx("postgres")
+		poolConfig, err := pgxpool.ParseConfig(baseConnString)
+		c.Assert(err, qt.IsNil)
+
+		var (
+			beforeConnectCalls atomic.Int32
+			afterConnectCalls  atomic.Int32
+			beforeAcquireCalls atomic.Int32
+			afterReleaseCalls  atomic.Int32
+			beforeCloseCalls   atomic.Int32
+		)
+		poolConfig.BeforeConnect = func(context.Context, *pgx.ConnConfig) error {
+			beforeConnectCalls.Add(1)
+			return nil
+		}
+		poolConfig.AfterConnect = func(context.Context, *pgx.Conn) error {
+			afterConnectCalls.Add(1)
+			return nil
+		}
+		poolConfig.BeforeAcquire = func(context.Context, *pgx.Conn) bool {
+			beforeAcquireCalls.Add(1)
+			return true
+		}
+		poolConfig.AfterRelease = func(*pgx.Conn) bool {
+			afterReleaseCalls.Add(1)
+			return true
+		}
+		poolConfig.BeforeClose = func(*pgx.Conn) {
+			beforeCloseCalls.Add(1)
+		}
+
+		provider := pgdbtemplatepgx.NewConnectionProvider(
+			testConnectionStringFuncPgx,
+			pgdbtemplatepgx.WithPoolConfig(*poolConfig),
+		)
+
+		conn, err := provider.Connect(ctx, "postgres")
+		c.Assert(err, qt.IsNil)
+		pgxConn, ok := conn.(*pgdbtemplatepgx.DatabaseConnection)
+		c.Assert(ok, qt.IsTrue)
+
+		// Acquire then release a connection to trigger BeforeAcquire and AfterRelease.
+		acquired, err := pgxConn.Pool.Acquire(ctx)
+		c.Assert(err, qt.IsNil)
+		acquired.Release()
+
+		// Close the pool to trigger BeforeClose for all pooled connections.
+		c.Assert(conn.Close(), qt.IsNil)
+
+		c.Assert(beforeConnectCalls.Load() >= 1, qt.IsTrue)
+		c.Assert(afterConnectCalls.Load() >= 1, qt.IsTrue)
+		c.Assert(beforeAcquireCalls.Load() >= 1, qt.IsTrue)
+		c.Assert(afterReleaseCalls.Load() >= 1, qt.IsTrue)
+		c.Assert(beforeCloseCalls.Load() >= 1, qt.IsTrue)
 	})
 
 	c.Run("Connection error handling", func(c *qt.C) {
@@ -231,6 +303,9 @@ func TestPgxConnectionProvider(t *testing.T) {
 		conn, err := provider.Connect(ctx, "postgres")
 		c.Assert(err, qt.IsNil)
 		defer func() { c.Assert(conn.Close(), qt.IsNil) }()
+		pgxConn, ok := conn.(*pgdbtemplatepgx.DatabaseConnection)
+		c.Assert(ok, qt.IsTrue)
+		c.Assert(pgxConn.Pool.Config().MaxConnLifetime, qt.Equals, 1*time.Hour)
 
 		// Verify the connection works.
 		var value int
@@ -252,6 +327,9 @@ func TestPgxConnectionProvider(t *testing.T) {
 		conn, err := provider.Connect(ctx, "postgres")
 		c.Assert(err, qt.IsNil)
 		defer func() { c.Assert(conn.Close(), qt.IsNil) }()
+		pgxConn, ok := conn.(*pgdbtemplatepgx.DatabaseConnection)
+		c.Assert(ok, qt.IsTrue)
+		c.Assert(pgxConn.Pool.Config().MaxConnIdleTime, qt.Equals, 30*time.Minute)
 
 		// Verify the connection works.
 		var value int


### PR DESCRIPTION
The `WithPoolConfig(config pgxpool.Config)` connection option respected not all the exported fields in the `pgxpool.Config` struct... this PR ensures all of them are properly used and tested.