### PR TITLE
fix: close shared admin pool only when last reference is released

### DIFF
--- a/connection_provider.go
+++ b/connection_provider.go
@@ -4,11 +4,18 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	"github.com/andrei-polukhin/pgdbtemplate"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+// poolEntry holds a connection pool and its active reference count.
+type poolEntry struct {
+	pool *pgxpool.Pool
+	refs atomic.Int32
+}
 
 // ConnectionProvider implements pgdbtemplate.ConnectionProvider
 // using pgx driver with connection pooling.
@@ -17,14 +24,14 @@ type ConnectionProvider struct {
 	poolConfig           pgxpool.Config
 
 	mu    sync.RWMutex
-	pools map[string]*pgxpool.Pool
+	pools map[string]*poolEntry
 }
 
 // NewConnectionProvider creates a new pgx-based connection provider.
 func NewConnectionProvider(connectionStringFunc func(string) string, opts ...ConnectionOption) *ConnectionProvider {
 	provider := &ConnectionProvider{
 		connectionStringFunc: connectionStringFunc,
-		pools:                make(map[string]*pgxpool.Pool),
+		pools:                make(map[string]*poolEntry),
 	}
 
 	for _, opt := range opts {
@@ -37,10 +44,11 @@ func NewConnectionProvider(connectionStringFunc func(string) string, opts ...Con
 func (p *ConnectionProvider) Connect(ctx context.Context, databaseName string) (pgdbtemplate.DatabaseConnection, error) {
 	// Check if we already have a pool for this database.
 	p.mu.RLock()
-	if pool, exists := p.pools[databaseName]; exists {
+	if entry, exists := p.pools[databaseName]; exists {
+		entry.refs.Add(1)
 		p.mu.RUnlock()
 		return &DatabaseConnection{
-			Pool:     pool,
+			Pool:     entry.pool,
 			provider: p,
 			dbName:   databaseName,
 		}, nil
@@ -52,8 +60,9 @@ func (p *ConnectionProvider) Connect(ctx context.Context, databaseName string) (
 	defer p.mu.Unlock()
 
 	// Double-check after acquiring write lock.
-	if pool, exists := p.pools[databaseName]; exists {
-		return &DatabaseConnection{Pool: pool, provider: p, dbName: databaseName}, nil
+	if entry, exists := p.pools[databaseName]; exists {
+		entry.refs.Add(1)
+		return &DatabaseConnection{Pool: entry.pool, provider: p, dbName: databaseName}, nil
 	}
 
 	// Parse connection string first.
@@ -76,7 +85,9 @@ func (p *ConnectionProvider) Connect(ctx context.Context, databaseName string) (
 		return nil, fmt.Errorf("failed to ping database: %w", err)
 	}
 
-	p.pools[databaseName] = pool
+	entry := &poolEntry{pool: pool}
+	entry.refs.Add(1)
+	p.pools[databaseName] = entry
 	return &DatabaseConnection{
 		Pool:     pool,
 		provider: p,
@@ -136,24 +147,24 @@ func (*ConnectionProvider) GetNoRowsSentinel() error {
 // Close closes all connection pools managed by this provider.
 //
 // This should be called when the provider is no longer needed, typically
-// in cleanup code or deferred calls. Note that individual DatabaseConnection.Close()
-// calls will also close their respective pools, so this is a safety net for
-// any remaining pools (e.g., the template database pool).
+// at the end of a test suite. It forcefully closes all pools regardless
+// of any outstanding references.
 func (p *ConnectionProvider) Close() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	for _, pool := range p.pools {
-		pool.Close()
+	for _, entry := range p.pools {
+		entry.pool.Close()
 	}
-	p.pools = make(map[string]*pgxpool.Pool)
+	p.pools = make(map[string]*poolEntry)
 }
 
 // DatabaseConnection implements pgdbtemplate.DatabaseConnection using pgx.
 type DatabaseConnection struct {
-	Pool     *pgxpool.Pool
-	provider *ConnectionProvider
-	dbName   string
+	Pool      *pgxpool.Pool
+	provider  *ConnectionProvider
+	dbName    string
+	closeOnce sync.Once
 }
 
 // ExecContext implements pgdbtemplate.DatabaseConnection.ExecContext.
@@ -170,24 +181,31 @@ func (c *DatabaseConnection) QueryRowContext(ctx context.Context, query string, 
 
 // Close implements pgdbtemplate.DatabaseConnection.Close.
 //
-// This closes and removes the pool for this database from the provider
-// if the pool has been created via Connect().
-//
-// In the pgdbtemplate usage pattern, each test database has a unique name,
-// so pools are not shared and can be safely closed when the connection closes.
+// It decrements the reference count of the underlying pool. The pool is
+// closed and removed from the provider only when the last reference is
+// released. Calling Close more than once is safe and has no effect after
+// the first call.
 func (c *DatabaseConnection) Close() error {
 	if c.provider == nil {
 		// Connection created without provider tracking.
 		// Happens if someone creates DatabaseConnection manually.
-		c.Pool.Close()
+		c.closeOnce.Do(c.Pool.Close)
 		return nil
 	}
 
-	c.provider.mu.Lock()
-	defer c.provider.mu.Unlock()
+	c.closeOnce.Do(func() {
+		c.provider.mu.Lock()
+		defer c.provider.mu.Unlock()
 
-	// Close and remove the pool for this database.
-	c.Pool.Close()
-	delete(c.provider.pools, c.dbName)
+		entry, exists := c.provider.pools[c.dbName]
+		if !exists {
+			// Pool was already removed, e.g. by provider.Close().
+			return
+		}
+		if entry.refs.Add(-1) == 0 {
+			entry.pool.Close()
+			delete(c.provider.pools, c.dbName)
+		}
+	})
 	return nil
 }

--- a/connection_provider_internal_test.go
+++ b/connection_provider_internal_test.go
@@ -1,0 +1,70 @@
+package pgdbtemplatepgx
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/andrei-polukhin/pgdbtemplate"
+)
+
+// TestConnectDoubleCheckPathWithoutHook exercises the write-lock double-check
+// path in Connect without any production test hooks.
+func TestConnectDoubleCheckPathWithoutHook(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+	ctx := context.Background()
+
+	baseConnString := os.Getenv("POSTGRES_CONNECTION_STRING")
+	c.Assert(baseConnString == "", qt.IsFalse)
+
+	provider := NewConnectionProvider(func(dbName string) string {
+		return pgdbtemplate.ReplaceDatabaseInConnectionString(baseConnString, dbName)
+	})
+	defer provider.Close()
+
+	const (
+		rounds     = 100
+		goroutines = 16
+	)
+
+	for round := 0; round < rounds; round++ {
+		start := make(chan struct{})
+		results := make(chan error, goroutines)
+		conns := make(chan pgdbtemplate.DatabaseConnection, goroutines)
+
+		// Hold write lock so all goroutines queue at the top of Connect first,
+		// then release together to maximize overlapping cold-path execution.
+		provider.mu.Lock()
+		for i := 0; i < goroutines; i++ {
+			go func() {
+				<-start
+				conn, err := provider.Connect(ctx, "postgres")
+				results <- err
+				conns <- conn
+			}()
+		}
+		close(start)
+		provider.mu.Unlock()
+
+		allConns := make([]pgdbtemplate.DatabaseConnection, 0, goroutines)
+		for i := 0; i < goroutines; i++ {
+			err := <-results
+			c.Assert(err, qt.IsNil)
+			allConns = append(allConns, <-conns)
+		}
+
+		var wg sync.WaitGroup
+		for _, conn := range allConns {
+			wg.Add(1)
+			go func(dc pgdbtemplate.DatabaseConnection) {
+				defer wg.Done()
+				c.Assert(dc.Close(), qt.IsNil)
+			}(conn)
+		}
+		wg.Wait()
+	}
+}

--- a/connection_provider_test.go
+++ b/connection_provider_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -705,4 +706,91 @@ func TestHighConcurrencyPoolCreation(t *testing.T) {
 	for _, conn := range conns {
 		conn.Close()
 	}
+}
+
+// TestSharedAdminPoolNotClosedUnderConcurrentUse is a regression test for the
+// bug where concurrent CreateTestDatabase / DropTestDatabase calls shared the
+// same admin pool via the pgx provider cache, and the first goroutine to finish
+// closed that shared pool via defer adminConn.Close(), killing in-flight
+// operations in sibling goroutines ("conn closed" / "context canceled" errors).
+//
+// With the ref-count fix, the pool is only closed after the last reference is
+// released, so concurrent users remain safe.
+func TestSharedAdminPoolNotClosedUnderConcurrentUse(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+	ctx := context.Background()
+
+	provider := pgdbtemplatepgx.NewConnectionProvider(testConnectionStringFuncPgx)
+	defer provider.Close()
+
+	const numGoroutines = 20
+
+	// Simulate numGoroutines concurrent callers each doing:
+	//   conn := Connect("postgres")  ← all share the same underlying pool
+	//   _ = conn.ExecContext(...)     ← work while others may be closing
+	//   conn.Close()                  ← must not destroy pool for siblings
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			<-start
+
+			conn, err := provider.Connect(ctx, "postgres")
+			c.Assert(err, qt.IsNil, qt.Commentf("goroutine %d Connect", n))
+			defer func() { c.Assert(conn.Close(), qt.IsNil) }()
+
+			var v int
+			row := conn.QueryRowContext(ctx, fmt.Sprintf("SELECT %d", n))
+			err = row.Scan(&v)
+			c.Assert(err, qt.IsNil, qt.Commentf("goroutine %d Scan", n))
+			c.Assert(v, qt.Equals, n)
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+}
+
+// TestRefCountPoolReleasedAfterAllConnectionsClosed verifies that the
+// underlying pool is actually closed and removed from the provider once every
+// DatabaseConnection that shares it has been closed — i.e. ref-counting reaches
+// zero exactly when expected.
+func TestRefCountPoolReleasedAfterAllConnectionsClosed(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+	ctx := context.Background()
+
+	provider := pgdbtemplatepgx.NewConnectionProvider(testConnectionStringFuncPgx)
+	defer provider.Close()
+
+	const n = 10
+	conns := make([]pgdbtemplate.DatabaseConnection, n)
+	for i := range conns {
+		conn, err := provider.Connect(ctx, "postgres")
+		c.Assert(err, qt.IsNil)
+		conns[i] = conn
+	}
+
+	// Close all but one — pool must still be alive.
+	for i := 0; i < n-1; i++ {
+		c.Assert(conns[i].Close(), qt.IsNil)
+	}
+	var v int
+	err := conns[n-1].QueryRowContext(ctx, "SELECT 1").Scan(&v)
+	c.Assert(err, qt.IsNil, qt.Commentf("pool must still be usable while last reference is held"))
+
+	// Close the last one — pool should now be gone.
+	c.Assert(conns[n-1].Close(), qt.IsNil)
+
+	// Reconnecting must succeed (creates a fresh pool, not a closed one).
+	newConn, err := provider.Connect(ctx, "postgres")
+	c.Assert(err, qt.IsNil)
+	defer func() { c.Assert(newConn.Close(), qt.IsNil) }()
+	err = newConn.QueryRowContext(ctx, "SELECT 1").Scan(&v)
+	c.Assert(err, qt.IsNil)
+	c.Assert(v, qt.Equals, 1)
 }


### PR DESCRIPTION
The pgx ConnectionProvider caches one *pgxpool.Pool per database name. When TemplateManager.CreateTestDatabase or DropTestDatabase ran concurrently, every goroutine received a DatabaseConnection that pointed to the same underlying pool for the admin database ("postgres" by default). The first goroutine to return ran its deferred adminConn.Close(), which closed and deleted the shared pool. Any sibling goroutine that was still mid-query against that pool then failed with "conn closed" or "failed SASL auth: context canceled".

The mutex in ConnectionProvider only protects the map, not the pool's lifetime. Once Connect returns, the lock is released and any caller can destroy the pool at any time.

Fix this by adding a reference count to each poolEntry. Connect increments the count; DatabaseConnection.Close decrements it. The underlying pool is closed and removed from the map only when the count reaches zero. For test databases, which always have a unique name and therefore a single reference, the behaviour is identical to before. DatabaseConnection.Close is made idempotent via sync.Once to prevent double-decrement on repeated calls.

Add two regression tests that exercise the fix under the race detector:
- TestSharedAdminPoolNotClosedUnderConcurrentUse: concurrent goroutines share the same pool and close independently; verifies no goroutine sees a closed pool while siblings are still active.
- TestRefCountPoolReleasedAfterAllConnectionsClosed: verifies the pool is still alive until the last reference is released, then removed so a subsequent Connect creates a fresh pool cleanly.

Closes #14.